### PR TITLE
Add sample Lustre SSG blog

### DIFF
--- a/example_blog/README.md
+++ b/example_blog/README.md
@@ -1,0 +1,5 @@
+# Example Blog
+
+This directory demonstrates a simple blog built with `lustre_ssg`.
+
+Run `gleam run -m build` in the `src` directory to generate the site in `priv/`.

--- a/example_blog/gleam.toml
+++ b/example_blog/gleam.toml
@@ -1,0 +1,10 @@
+name = "example_blog"
+version = "0.1.0"
+description = "Example blog built with lustre_ssg"
+gleam = ">= 1.6.0"
+
+[dependencies]
+lustre = ">= 5.0.0 and < 6.0.0"
+lustre_ssg = { path = ".." }
+
+[dev-dependencies]

--- a/example_blog/posts/another.dj
+++ b/example_blog/posts/another.dj
@@ -1,0 +1,8 @@
+---
+title = "Another Entry"
+date = "2024-06-19"
+---
+
+# Another Entry
+
+More content in Djot.

--- a/example_blog/posts/hello.dj
+++ b/example_blog/posts/hello.dj
@@ -1,0 +1,8 @@
+---
+title = "Hello from Lustre"
+date = "2024-06-18"
+---
+
+# Hello from Lustre
+
+Welcome to your first blog post written in Djot!

--- a/example_blog/src/app/component/header.gleam
+++ b/example_blog/src/app/component/header.gleam
@@ -1,0 +1,10 @@
+import lustre/element.{element, type Element, html}
+import lustre/attribute.{attribute}
+
+pub fn view() -> Element(a) {
+  html.nav([], [
+    html.a([attribute.href("/index.html")], [html.text("Home")]),
+    html.text(" | "),
+    html.a([attribute.href("/about.html")], [html.text("About")])
+  ])
+}

--- a/example_blog/src/app/data/posts.gleam
+++ b/example_blog/src/app/data/posts.gleam
@@ -1,0 +1,39 @@
+import gleam/list
+import gleam/dict
+import lustre/ssg/djot
+import simplifile
+import lustre/element.{Element}
+import tom
+
+pub type Post {
+  Post(
+    id: String,
+    title: String,
+    date: String,
+    content: List(Element(Nil))
+  )
+}
+
+pub fn all() -> List(Post) {
+  case simplifile.read_directory("./posts") {
+    Ok(files) ->
+      files
+      |> list.filter(fn(name) { string.ends_with(name, ".dj") })
+      |> list.map(load_post)
+    Error(_) -> []
+  }
+}
+
+fn load_post(filename: String) -> Post {
+  let assert Ok(content) = simplifile.read("./posts/" <> filename)
+  let assert Ok(elements) = djot.render_with_metadata(content, fn(metadata) {
+    djot.default_renderer()
+  })
+
+  let Ok(meta) = djot.metadata(content)
+  let title = case dict.get(meta, "title") { Ok(t) -> tom.to_string(t); _ -> "" }
+  let date = case dict.get(meta, "date") { Ok(t) -> tom.to_string(t); _ -> "" }
+  let id = string.drop_end(filename, 3) // remove .dj
+
+  Post(id, title, date, elements)
+}

--- a/example_blog/src/app/page/about.gleam
+++ b/example_blog/src/app/page/about.gleam
@@ -1,0 +1,10 @@
+import lustre/element.{type Element, html}
+import app/component/header
+
+pub fn view() -> Element(a) {
+  html.div([], [
+    header.view(),
+    html.h1([], [html.text("About")]),
+    html.p([], [html.text("This is a small example blog using lustre_ssg")])
+  ])
+}

--- a/example_blog/src/app/page/index.gleam
+++ b/example_blog/src/app/page/index.gleam
@@ -1,0 +1,20 @@
+import gleam/list
+import lustre/attribute.{attribute}
+import lustre/element.{type Element, html}
+import app/component/header
+import app/data/posts.{Post}
+
+pub fn view(posts: List(Post)) -> Element(a) {
+  let post_links = posts
+    |> list.map(fn(post) {
+        html.li([], [
+          html.a([attribute.href("/blog/" <> post.id <> ".html")], [html.text(post.title)])
+        ])
+    })
+
+  html.div([], [
+    header.view(),
+    html.h1([], [html.text("My Blog")]),
+    html.ul([], post_links)
+  ])
+}

--- a/example_blog/src/app/page/post.gleam
+++ b/example_blog/src/app/page/post.gleam
@@ -1,0 +1,12 @@
+import lustre/element.{type Element, html}
+import app/component/header
+import app/data/posts.{Post}
+
+pub fn view(post: Post) -> Element(a) {
+  html.div([], [
+    header.view(),
+    html.h1([], [html.text(post.title)]),
+    html.p([], [html.text(post.date)]),
+    html.div([], post.content)
+  ])
+}

--- a/example_blog/src/build.gleam
+++ b/example_blog/src/build.gleam
@@ -1,0 +1,27 @@
+import gleam/io
+import gleam/list
+import gleam/dict
+import lustre/ssg
+import app/data/posts
+import app/page/index
+import app/page/about
+import app/page/post
+
+pub fn main() {
+  let posts = posts.all()
+  let post_map =
+    list.map(posts, fn(p) { #(p.id, p) })
+    |> dict.from_list()
+
+  let result =
+    ssg.new("./priv")
+    |> ssg.add_static_route("/", index.view(posts))
+    |> ssg.add_static_route("/about", about.view())
+    |> ssg.add_dynamic_route("/blog", post_map, post.view)
+    |> ssg.build
+
+  case result {
+    Ok(_) -> io.println("Build succeeded")
+    Error(e) -> io.debug(e)
+  }
+}


### PR DESCRIPTION
## Summary
- create an example blog implementation using lustre_ssg
- show how to render posts from Djot files
- include universal header component

## Testing
- `gleam format --check` *(fails: command not found)*
- `gleam test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853757977408328985cdcf9df7fdc55